### PR TITLE
add keys & per-key products for apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>maven-plugin</packaging>
   <name>apigee-config-maven-plugin</name>
   <description>Plugin to manage configuration in Apigee</description>
-  <url>https://github.com/apigee/apigee-config-maven-plugin</url>
+  <url>https://github.com/IanWillard/apigee-config-maven-plugin</url>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>maven-plugin</packaging>
   <name>apigee-config-maven-plugin</name>
   <description>Plugin to manage configuration in Apigee</description>
-  <url>https://github.com/IanWillard/apigee-config-maven-plugin</url>
+  <url>https://github.com/apigee/apigee-config-maven-plugin</url>
 
   <licenses>
     <license>

--- a/samples/APIandConfig/HelloWorld/edge.json
+++ b/samples/APIandConfig/HelloWorld/edge.json
@@ -124,7 +124,13 @@
             "john@example.com": [
                 {
                     "name": "coolapp",
-                    "apiProducts": [ "DecTraining" ],
+                    "keys": [
+                        "consumerKey": "i8wVEIbuLtedoy4gJE3IukSq2Gww0trT",
+                        "consumerSecret": "x8tFPqcmEAXm8ewG",
+                        "apiProducts": [
+                            "DecTraining"
+                        ],
+                    ],
                     "callbackUrl": "http://weatherapp.com",
                     "scopes": []
                 }

--- a/samples/EdgeConfig/edge.json
+++ b/samples/EdgeConfig/edge.json
@@ -148,8 +148,12 @@
             "bill@unesco.com": [
                 {
                     "name": "oneapp",
-                    "apiProducts": [
-                        "weatherProduct"
+                    "keys": [
+                        "consumerKey": "i8wVEIbuLtedoy4gJE3IukSq2Gww0trT",
+                        "consumerSecret": "x8tFPqcmEAXm8ewG",
+                        "apiProducts": [
+                            "weatherProduct"
+                        ],
                     ],
                     "callbackUrl": "http://weatherapp.com",
                     "scopes": []

--- a/src/main/java/com/apigee/edge/config/utils/PrintUtil.java
+++ b/src/main/java/com/apigee/edge/config/utils/PrintUtil.java
@@ -56,23 +56,24 @@ public class PrintUtil {
         }
 
         try {
-        if (request.getMethod().compareTo(HttpMethod.POST) == 0  ){
-
-            if (request.getContent()!=null && request.getContent().getType() !=null)
-            {
-                prettyRequest = prettyRequest + "\n" + "content-type" + ": " + request.getContent().getType();
-
-                if (!request.getContent().getType().contains("octet"))
+            if (request.getMethod().compareTo(HttpMethod.POST) == 0 ||
+                    request.getMethod().compareTo(HttpMethod.PUT) == 0) {
+    
+                if (request.getContent()!=null && request.getContent().getType() !=null)
                 {
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                request.getContent().writeTo(out);
-                prettyRequest = prettyRequest + "\n [Request body]\n" + out.toString();
-                } else {
-                    prettyRequest = prettyRequest + "\n [Request body contains data, not shown] \n";
+                    prettyRequest = prettyRequest + "\n" + "content-type" + ": " + request.getContent().getType();
+    
+                    if (!request.getContent().getType().contains("octet"))
+                    {
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    request.getContent().writeTo(out);
+                    prettyRequest = prettyRequest + "\n [Request body]\n" + out.toString();
+                    } else {
+                        prettyRequest = prettyRequest + "\n [Request body contains data, not shown] \n";
+                    }
                 }
+    
             }
-
-        }
         }catch (Exception e){
             e.printStackTrace();
         }


### PR DESCRIPTION
Adding the ability to specify specific keys and associate them to specific products within a given app.  The intent is to allow an apigee server to be cloned such that clients are not aware of the change (and do not need to be re-released with new keys), or to allow for multiple products to be associated to a single key within a given app.