### PR TITLE
Fix for #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ mvn install -Ptest -Dapigee.config.options=create
     delete - Delete all config listed in edge.json.
     sync   - Delete and recreate.
 
+  -Dapigee.config.file=<path-to-config>
+     path containing the configuration.
+  
   -Dapigee.config.dir=<dir>
      directory containing multi-file format config files.
      
@@ -81,6 +84,10 @@ To use, edit samples/EdgeConfig/shared-pom.xml, and update org and env elements 
 To run the plugin and use edge.json jump to samples project `cd /samples/EdgeConfig` and run 
 
 `mvn install -Ptest -Dusername=<your-apigee-username> -Dpassword=<your-apigee-password> -Dapigee.config.options=create`
+
+To run the plugin and use a config file similar to edge.json in any directory jump to samples project `cd /samples/EdgeConfig` and run 
+
+`mvn install -Ptest -Dusername=<your-apigee-username> -Dpassword=<your-apigee-password> -Dapigee.config.file=<path-to-config-file> -Dapigee.config.options=create`
 
 To run the plugin and use the multi-file config format jump to samples project `cd /samples/EdgeConfig` and run 
 

--- a/samples/APIandConfig/shared-pom.xml
+++ b/samples/APIandConfig/shared-pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>com.apigee.edge.config</groupId>
                 <artifactId>apigee-config-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.2.2</version>
                 <executions>
                     <execution>
                         <id>create-config-cache</id>

--- a/samples/EdgeConfig/shared-pom.xml
+++ b/samples/EdgeConfig/shared-pom.xml
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>com.apigee.edge.config</groupId>
                 <artifactId>apigee-config-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.2.2</version>
                 <executions>
                     <execution>
                         <id>create-config-cache</id>

--- a/samples/README.md
+++ b/samples/README.md
@@ -25,6 +25,10 @@ To run the plugin and use edge.json jump to samples project `cd /samples/EdgeCon
 
 `mvn install -Ptest -Dusername=<your-apigee-username> -Dpassword=<your-apigee-password> -Dapigee.config.options=create`
 
+To run the plugin and use a config file similar to edge.json in any directory jump to samples project `cd /samples/EdgeConfig` and run 
+
+`mvn install -Ptest -Dusername=<your-apigee-username> -Dpassword=<your-apigee-password> -Dapigee.config.file=<path-to-config-file> -Dapigee.config.options=create`
+
 To run the plugin and use the multi-file format jump to samples project `cd /samples/EdgeConfig` and run 
 
 `mvn install -Ptest -Dusername=<your-apigee-username> -Dpassword=<your-apigee-password> -Dapigee.config.options=create -Dapigee.config.dir=resources/edge`

--- a/src/main/java/com/apigee/edge/config/mavenplugin/GatewayAbstractMojo.java
+++ b/src/main/java/com/apigee/edge/config/mavenplugin/GatewayAbstractMojo.java
@@ -196,6 +196,12 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 	 */
 	private String clientsecret;
 	
+	/**
+	 * configuration file
+	 * @parameter property="apigee.config.file"
+ 	 */
+	private String configFilePath;
+	
 	// TODO set resources/edge as default value
 
 	public String getExportDir() {
@@ -301,10 +307,14 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 
 	private File findConsolidatedConfigFile()
 			throws MojoExecutionException {
-		File configFile = new File(getBaseDirectoryPath() + File.separator +
-									"edge.json");
-		if (configFile.exists()) {
-			return configFile;
+		File fConfigFile = null;
+		if(configFilePath !=null && !configFilePath.equalsIgnoreCase("")){
+			fConfigFile = new File(configFilePath);
+		}else{
+			fConfigFile = new File(getBaseDirectoryPath() + File.separator +"edge.json");
+		}
+		if (fConfigFile.exists()) {
+			return fConfigFile;
 		}
 		return null;
 	}
@@ -345,11 +355,11 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 		configFile = findConsolidatedConfigFile();
 
 		if (configFile == null) {
-			logger.info("No edge.json found.");
-			throw new MojoExecutionException("config file edge.json not found");
+			logger.info("No edge.json or config file found.");
+			throw new MojoExecutionException("config file edge.json or config file not found");
 		}
 
-		logger.debug("Retrieving config from edge.json");
+		logger.info("Retrieving config from " + configFile.getAbsolutePath());
 		try {
 
 			return ConsolidatedConfigReader.getAPIConfig(configFile,
@@ -379,11 +389,11 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 		configFile = findConsolidatedConfigFile();
 
 		if (configFile == null) {
-			logger.info("No edge.json found.");
-			throw new MojoExecutionException("config file edge.json not found");
+			logger.info("No edge.json or config file found.");
+			throw new MojoExecutionException("config file edge.json or config file not found");
 		}
 
-		logger.debug("Retrieving config from edge.json");
+		logger.info("Retrieving config from " + configFile.getAbsolutePath());
 		try {
 			return ConsolidatedConfigReader.getAPIList(configFile);
 		} catch (Exception e) {
@@ -418,13 +428,13 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 
 		/* consolidated edge.json in CWD as fallback */
 		configFile = findConsolidatedConfigFile();
-
+		
 		if (configFile == null) {
-			logger.info("No edge.json found.");
-			throw new MojoExecutionException("config file edge.json not found");
+			logger.info("No edge.json or config file found.");
+			throw new MojoExecutionException("config file edge.json or config file not found");
 		}
 
-		logger.debug("Retrieving config from edge.json");
+		logger.info("Retrieving config from " + configFile.getAbsolutePath());
 		try {
 			List envConfigs = ConsolidatedConfigReader.getEnvConfig(
 					this.buildProfile.getEnvironment(),
@@ -462,11 +472,11 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 		configFile = findConsolidatedConfigFile();
 
 		if (configFile == null) {
-			logger.info("No edge.json found.");
-			throw new MojoExecutionException("config file edge.json not found");
+			logger.info("No edge.json or config file found.");
+			throw new MojoExecutionException("config file edge.json or config file not found");
 		}
 
-		logger.debug("Retrieving config from edge.json");
+		logger.info("Retrieving config from " + configFile.getAbsolutePath());
 		try {
 			return ConsolidatedConfigReader.getOrgConfig(configFile,
 															"orgConfig",
@@ -501,11 +511,11 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 		configFile = findConsolidatedConfigFile();
 
 		if (configFile == null) {
-			logger.info("No edge.json found.");
-			throw new MojoExecutionException("config file edge.json not found");
+			logger.info("No edge.json or config file found.");
+			throw new MojoExecutionException("config file edge.json or config file not found");
 		}
 
-		logger.debug("Retrieving config from edge.json");
+		logger.info("Retrieving config from " + configFile.getAbsolutePath());
 		try {
 			return ConsolidatedConfigReader.getOrgConfigWithId(configFile,
 					"orgConfig",

--- a/src/main/java/com/apigee/edge/config/mavenplugin/MaskConfigMojo.java
+++ b/src/main/java/com/apigee/edge/config/mavenplugin/MaskConfigMojo.java
@@ -281,7 +281,7 @@ public class MaskConfigMojo extends GatewayAbstractMojo
             /* API scoped Masks */
             Set<String> apis = getAPIList(logger);
             if (apis == null || apis.size() == 0) {
-                logger.info("No API scoped Mask config found in edge.json.");
+                logger.info("No API scoped Mask config found in edge.json or config file");
                 return;
             }
 
@@ -289,7 +289,7 @@ public class MaskConfigMojo extends GatewayAbstractMojo
                 maskConfigs = getAPIConfig(logger, "maskconfigs", api);
                 if (maskConfigs == null || maskConfigs.size() == 0) {
                     logger.info(
-                        "No API scoped Mask config found in edge.json.");
+                        "No API scoped Mask config found in edge.json or config file");
                 } else {
                     doAPIUpdate(api, maskConfigs);
                 }

--- a/src/main/java/com/apigee/edge/config/utils/ConsolidatedConfigReader.java
+++ b/src/main/java/com/apigee/edge/config/utils/ConsolidatedConfigReader.java
@@ -41,7 +41,7 @@ import org.json.simple.parser.ParseException;
 import java.io.IOException;
 
 /**
- * Read config from edge.json
+ * Read config from edge.json or config file
  *
  * @author madhan.sadasivam
  */


### PR DESCRIPTION
Fix for https://github.com/apigee/apigee-config-maven-plugin/issues/34
- Include `apigee.config.file` as an argument to pass a config file in stead of defaulting it to the current working directory
- Defaults if argument not passed
- Will help with CI/CD process if the pipeline updates the config file from source code